### PR TITLE
feat: Auto-inject Vite allowedHosts with devDomain during zdev start

### DIFF
--- a/src/vite-patch.test.ts
+++ b/src/vite-patch.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { patchViteAllowedHosts } from "./vite-patch.js";
+import { writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const DEV_DOMAIN = "dev.web3citadel.com";
+const DOMAIN_PATTERN = ".dev.web3citadel.com";
+
+let tmpDir: string;
+let configPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "vite-patch-test-"));
+  configPath = join(tmpDir, "vite.config.ts");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeConfig(content: string): string {
+  writeFileSync(configPath, content);
+  return configPath;
+}
+
+function readConfig(): string {
+  return readFileSync(configPath, "utf-8");
+}
+
+describe("patchViteAllowedHosts", () => {
+  // ── Skip conditions ─────────────────────────────────────────────
+
+  it("skips when devDomain is empty", () => {
+    writeConfig(`export default defineConfig({ plugins: [] })`);
+    const result = patchViteAllowedHosts(configPath, "");
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe("no devDomain configured");
+  });
+
+  it("skips when file cannot be read", () => {
+    const result = patchViteAllowedHosts("/nonexistent/vite.config.ts", DEV_DOMAIN);
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe("could not read vite config");
+  });
+
+  it("skips when domain pattern already present", () => {
+    writeConfig(`
+export default defineConfig({
+  server: {
+    allowedHosts: ["${DOMAIN_PATTERN}"],
+  },
+  plugins: [],
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe("domain already present");
+  });
+
+  it("skips when allowedHosts is true", () => {
+    writeConfig(`
+export default defineConfig({
+  server: {
+    allowedHosts: true,
+  },
+  plugins: [],
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe("already allows all hosts (true)");
+  });
+
+  it('skips when allowedHosts is "all"', () => {
+    writeConfig(`
+export default defineConfig({
+  server: {
+    allowedHosts: "all",
+  },
+  plugins: [],
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe('already allows all hosts ("all")');
+  });
+
+  it("returns unrecognized for non-matching format", () => {
+    writeConfig(`// just a comment, no config object`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe("unrecognized config format");
+  });
+
+  // ── Inline defineConfig ─────────────────────────────────────────
+
+  it("injects server block into inline defineConfig", () => {
+    writeConfig(`import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+
+export default defineConfig({
+  plugins: [react()],
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`server: {`);
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(output).toContain(`plugins: [react()]`);
+  });
+
+  // ── Variable-assigned defineConfig ──────────────────────────────
+
+  it("injects server block into variable-assigned defineConfig", () => {
+    writeConfig(`import { defineConfig } from 'vite'
+import viteReact from '@vitejs/plugin-react'
+
+const config = defineConfig({
+  plugins: [
+    viteReact(),
+  ],
+})
+
+export default config`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`server: {`);
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(output).toContain(`export default config`);
+  });
+
+  // ── Plain export default { } ────────────────────────────────────
+
+  it("injects server block into plain export default object", () => {
+    writeConfig(`export default {
+  plugins: [],
+}`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`server: {`);
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+  });
+
+  // ── Existing server block, no allowedHosts ──────────────────────
+
+  it("merges allowedHosts into existing server block", () => {
+    writeConfig(`export default defineConfig({
+  server: {
+    port: 3000,
+    host: "0.0.0.0",
+  },
+  plugins: [],
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(output).toContain(`port: 3000`);
+    expect(output).toContain(`host: "0.0.0.0"`);
+  });
+
+  // ── Existing allowedHosts array, different domain ───────────────
+
+  it("appends domain to existing allowedHosts array", () => {
+    writeConfig(`export default defineConfig({
+  server: {
+    allowedHosts: ["other.example.com"],
+  },
+  plugins: [],
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`"${DOMAIN_PATTERN}"`);
+    expect(output).toContain(`"other.example.com"`);
+  });
+
+  // ── Real-world configs from Workstellar repos ───────────────────
+
+  it("patches nft-indexer-provisioner style config", () => {
+    writeConfig(`import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import tailwindcss from "@tailwindcss/vite"
+import { resolve } from "path"
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+})`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`server: {`);
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    // Preserve existing content
+    expect(output).toContain(`plugins: [react(), tailwindcss()]`);
+    expect(output).toContain(`resolve:`);
+  });
+
+  it("patches clean-it-platform style config (variable assignment)", () => {
+    writeConfig(`import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+const config = defineConfig({
+  plugins: [
+    tailwindcss(),
+    tanstackStart(),
+    viteReact(),
+  ],
+})
+
+export default config`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`server: {`);
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(output).toContain(`export default config`);
+  });
+
+  it("skips nft-marketplace style config (already has allowedHosts: true)", () => {
+    writeConfig(`import { defineConfig } from 'vite'
+import viteReact from '@vitejs/plugin-react'
+
+const config = defineConfig({
+  server: {
+    allowedHosts: true,
+  },
+  plugins: [
+    viteReact(),
+  ],
+})
+
+export default config`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(false);
+    expect(result.reason).toBe("already allows all hosts (true)");
+  });
+
+  it("patches degen-safe style config (variable, no server block, extra options)", () => {
+    writeConfig(`import { defineConfig } from 'vite'
+import viteReact from '@vitejs/plugin-react'
+
+const config = defineConfig({
+  plugins: [
+    viteReact(),
+  ],
+  optimizeDeps: {
+    include: ['@raydium-io/raydium-sdk-v2'],
+  },
+  ssr: {
+    external: ['lodash'],
+  },
+})
+
+export default config`);
+    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    expect(result.patched).toBe(true);
+    const output = readConfig();
+    expect(output).toContain(`server: {`);
+    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(output).toContain(`optimizeDeps:`);
+    expect(output).toContain(`ssr:`);
+  });
+});

--- a/src/vite-patch.ts
+++ b/src/vite-patch.ts
@@ -1,0 +1,100 @@
+import { readFileSync, writeFileSync } from "fs";
+
+export interface PatchResult {
+  patched: boolean;
+  reason: string;
+}
+
+/**
+ * Patch a Vite config file to include `server.allowedHosts` with the given devDomain.
+ *
+ * Handles these real-world patterns:
+ *   1. `export default defineConfig({ ... })`
+ *   2. `const config = defineConfig({ ... }); export default config`
+ *   3. `export default { ... }` (plain object, no defineConfig)
+ *   4. Existing `server:` block — merges allowedHosts into it
+ *   5. Existing `allowedHosts` array — appends domain if missing
+ *
+ * Skip conditions:
+ *   - File already contains the domain pattern string
+ *   - `allowedHosts` is set to `true` or `"all"` (already permissive)
+ *   - devDomain is empty
+ */
+export function patchViteAllowedHosts(
+  viteConfigPath: string,
+  devDomain: string
+): PatchResult {
+  if (!devDomain) {
+    return { patched: false, reason: "no devDomain configured" };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(viteConfigPath, "utf-8");
+  } catch {
+    return { patched: false, reason: "could not read vite config" };
+  }
+
+  const domainPattern = `.${devDomain}`;
+
+  // Skip if domain pattern already present in the file
+  if (content.includes(domainPattern)) {
+    return { patched: false, reason: "domain already present" };
+  }
+
+  // Skip if allowedHosts is already set to a permissive value
+  if (/allowedHosts\s*:\s*true/.test(content)) {
+    return { patched: false, reason: "already allows all hosts (true)" };
+  }
+  if (/allowedHosts\s*:\s*["']all["']/.test(content)) {
+    return { patched: false, reason: 'already allows all hosts ("all")' };
+  }
+
+  const entry = `"${domainPattern}"`;
+  let patched = false;
+
+  // Case 1: Existing allowedHosts array — append our domain
+  if (/allowedHosts\s*:\s*\[/.test(content)) {
+    content = content.replace(
+      /(allowedHosts\s*:\s*\[)/,
+      `$1${entry}, `
+    );
+    patched = true;
+  }
+  // Case 2: Existing server block without allowedHosts — inject allowedHosts
+  else if (/server\s*:\s*\{/.test(content)) {
+    content = content.replace(
+      /(server\s*:\s*\{)/,
+      `$1\n    allowedHosts: [${entry}],`
+    );
+    patched = true;
+  }
+  // Case 3: defineConfig({ — add server block
+  else if (/defineConfig\s*\(\s*\{/.test(content)) {
+    content = content.replace(
+      /(defineConfig\s*\(\s*\{)/,
+      `$1\n  server: {\n    allowedHosts: [${entry}],\n  },`
+    );
+    patched = true;
+  }
+  // Case 4: export default { — add server block
+  else if (/export\s+default\s*\{/.test(content)) {
+    content = content.replace(
+      /(export\s+default\s*\{)/,
+      `$1\n  server: {\n    allowedHosts: [${entry}],\n  },`
+    );
+    patched = true;
+  }
+
+  if (!patched) {
+    return { patched: false, reason: "unrecognized config format" };
+  }
+
+  try {
+    writeFileSync(viteConfigPath, content);
+  } catch {
+    return { patched: false, reason: "could not write vite config" };
+  }
+
+  return { patched: true, reason: "added allowedHosts" };
+}


### PR DESCRIPTION
## Summary

Fixes Vite 7.x blocking external hostnames on zdev preview URLs (403 errors).

When `zdev start` launches a dev server, it now reads `devDomain` from `~/.zdev/config.json` and auto-injects `server.allowedHosts: [".<devDomain>"]` into the project's `vite.config.ts`.

## Changes

- **`src/vite-patch.ts`** (NEW) — extracted vite config patching into a dedicated module
- **`src/vite-patch.test.ts`** (NEW) — 15 unit tests covering all config patterns and skip conditions
- **`src/commands/start.ts`** — replaced inline regex patching (~30 lines) with call to `patchViteAllowedHosts()`

## What it handles

| Pattern | Action |
|---------|--------|
| `defineConfig({...})` (inline or variable) | Injects `server` block |
| `export default {...}` (plain object) | Injects `server` block |
| Existing `server:` block | Merges `allowedHosts` into it |
| Existing `allowedHosts` array | Appends domain if missing |
| `allowedHosts: true` or `"all"` | Skips (already permissive) |
| Domain already present | Skips |

## Before → After

**Before:** Hardcoded `allowedHosts: true`, fragile regex, only handled `defineConfig({` pattern.

**After:** Reads `devDomain` dynamically, handles 5 real-world patterns found across Workstellar repos, proper skip logic, 15 unit tests.

## Testing

```bash
bun test src/vite-patch.test.ts
# 15 pass, 0 fail
```

Closes #1