### PR TITLE
fix: inject server.port and unique devtools port into vite config

### DIFF
--- a/src/vite-patch.test.ts
+++ b/src/vite-patch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { patchViteAllowedHosts } from "./vite-patch.js";
+import { patchViteConfig, patchViteAllowedHosts } from "./vite-patch.js";
 import { writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -28,187 +28,223 @@ function readConfig(): string {
   return readFileSync(configPath, "utf-8");
 }
 
-describe("patchViteAllowedHosts", () => {
-  // ── Skip conditions ─────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════════════════
+// allowedHosts
+// ═══════════════════════════════════════════════════════════════════
 
-  it("skips when devDomain is empty", () => {
+describe("allowedHosts", () => {
+  it("skips when devDomain is not provided", () => {
     writeConfig(`export default defineConfig({ plugins: [] })`);
-    const result = patchViteAllowedHosts(configPath, "");
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe("no devDomain configured");
+    const result = patchViteConfig(configPath, { serverPort: 5173 });
+    expect(result.actions).not.toContain(expect.stringContaining("allowedHosts"));
   });
 
-  it("skips when file cannot be read", () => {
-    const result = patchViteAllowedHosts("/nonexistent/vite.config.ts", DEV_DOMAIN);
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe("could not read vite config");
-  });
-
-  it("skips when domain pattern already present", () => {
-    writeConfig(`
-export default defineConfig({
-  server: {
-    allowedHosts: ["${DOMAIN_PATTERN}"],
-  },
-  plugins: [],
+  it("skips when domain already present", () => {
+    writeConfig(`export default defineConfig({
+  server: { allowedHosts: ["${DOMAIN_PATTERN}"] },
 })`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe("domain already present");
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
+    expect(result.actions).toContain("allowedHosts: domain already present");
   });
 
   it("skips when allowedHosts is true", () => {
-    writeConfig(`
-export default defineConfig({
-  server: {
-    allowedHosts: true,
-  },
-  plugins: [],
+    writeConfig(`export default defineConfig({
+  server: { allowedHosts: true },
 })`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe("already allows all hosts (true)");
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
+    expect(result.actions).toContain("allowedHosts: already allows all (true)");
   });
 
   it('skips when allowedHosts is "all"', () => {
-    writeConfig(`
-export default defineConfig({
-  server: {
-    allowedHosts: "all",
-  },
+    writeConfig(`export default defineConfig({
+  server: { allowedHosts: "all" },
+})`);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
+    expect(result.actions).toContain('allowedHosts: already allows all ("all")');
+  });
+
+  it("injects server block into defineConfig", () => {
+    writeConfig(`export default defineConfig({
   plugins: [],
 })`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe('already allows all hosts ("all")');
-  });
-
-  it("returns unrecognized for non-matching format", () => {
-    writeConfig(`// just a comment, no config object`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe("unrecognized config format");
-  });
-
-  // ── Inline defineConfig ─────────────────────────────────────────
-
-  it("injects server block into inline defineConfig", () => {
-    writeConfig(`import { defineConfig } from "vite"
-import react from "@vitejs/plugin-react"
-
-export default defineConfig({
-  plugins: [react()],
-})`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`server: {`);
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
-    expect(output).toContain(`plugins: [react()]`);
+    const out = readConfig();
+    expect(out).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
   });
 
-  // ── Variable-assigned defineConfig ──────────────────────────────
-
-  it("injects server block into variable-assigned defineConfig", () => {
-    writeConfig(`import { defineConfig } from 'vite'
-import viteReact from '@vitejs/plugin-react'
-
-const config = defineConfig({
-  plugins: [
-    viteReact(),
-  ],
+  it("injects into variable-assigned defineConfig", () => {
+    writeConfig(`const config = defineConfig({
+  plugins: [],
 })
-
 export default config`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`server: {`);
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
-    expect(output).toContain(`export default config`);
+    expect(readConfig()).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
   });
 
-  // ── Plain export default { } ────────────────────────────────────
-
-  it("injects server block into plain export default object", () => {
+  it("injects into plain export default object", () => {
     writeConfig(`export default {
   plugins: [],
 }`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`server: {`);
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(readConfig()).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
   });
 
-  // ── Existing server block, no allowedHosts ──────────────────────
+  it("merges into existing server block", () => {
+    writeConfig(`export default defineConfig({
+  server: {
+    host: "0.0.0.0",
+  },
+})`);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(out).toContain(`host: "0.0.0.0"`);
+  });
 
-  it("merges allowedHosts into existing server block", () => {
+  it("appends to existing allowedHosts array", () => {
+    writeConfig(`export default defineConfig({
+  server: {
+    allowedHosts: ["other.example.com"],
+  },
+})`);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain(`"${DOMAIN_PATTERN}"`);
+    expect(out).toContain(`"other.example.com"`);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// server.port
+// ═══════════════════════════════════════════════════════════════════
+
+describe("server.port", () => {
+  it("injects port into existing server block", () => {
+    writeConfig(`export default defineConfig({
+  server: {
+    host: "0.0.0.0",
+  },
+})`);
+    const result = patchViteConfig(configPath, { serverPort: 5188 });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain("port: 5188,");
+    expect(out).toContain(`host: "0.0.0.0"`);
+  });
+
+  it("creates server block with port in defineConfig", () => {
+    writeConfig(`export default defineConfig({
+  plugins: [],
+})`);
+    const result = patchViteConfig(configPath, { serverPort: 5188 });
+    expect(result.patched).toBe(true);
+    expect(readConfig()).toContain("port: 5188,");
+  });
+
+  it("creates server block with port in plain export", () => {
+    writeConfig(`export default {
+  plugins: [],
+}`);
+    const result = patchViteConfig(configPath, { serverPort: 5188 });
+    expect(result.patched).toBe(true);
+    expect(readConfig()).toContain("port: 5188,");
+  });
+
+  it("replaces existing server.port", () => {
     writeConfig(`export default defineConfig({
   server: {
     port: 3000,
     host: "0.0.0.0",
   },
-  plugins: [],
 })`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    const result = patchViteConfig(configPath, { serverPort: 5188 });
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
-    expect(output).toContain(`port: 3000`);
-    expect(output).toContain(`host: "0.0.0.0"`);
+    const out = readConfig();
+    expect(out).toContain("port: 5188");
+    expect(out).not.toContain("3000");
   });
+});
 
-  // ── Existing allowedHosts array, different domain ───────────────
+// ═══════════════════════════════════════════════════════════════════
+// devtools port
+// ═══════════════════════════════════════════════════════════════════
 
-  it("appends domain to existing allowedHosts array", () => {
+describe("devtools port", () => {
+  it("skips when no devtools call present", () => {
     writeConfig(`export default defineConfig({
-  server: {
-    allowedHosts: ["other.example.com"],
-  },
-  plugins: [],
+  plugins: [react()],
 })`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
-    expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`"${DOMAIN_PATTERN}"`);
-    expect(output).toContain(`"other.example.com"`);
+    const result = patchViteConfig(configPath, { devtoolsPort: 42188 });
+    expect(result.patched).toBe(false);
+    expect(result.actions).toContain("devtools: not found, skipped");
   });
 
-  // ── Real-world configs from Workstellar repos ───────────────────
-
-  it("patches nft-indexer-provisioner style config", () => {
-    writeConfig(`import { defineConfig } from "vite"
-import react from "@vitejs/plugin-react"
-import tailwindcss from "@tailwindcss/vite"
-import { resolve } from "path"
-
+  it("injects eventBusConfig into devtools()", () => {
+    writeConfig(`import { devtools } from '@tanstack/devtools-vite'
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
-    },
-  },
+  plugins: [
+    devtools(),
+    react(),
+  ],
 })`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    const result = patchViteConfig(configPath, { devtoolsPort: 42188 });
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`server: {`);
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
-    // Preserve existing content
-    expect(output).toContain(`plugins: [react(), tailwindcss()]`);
-    expect(output).toContain(`resolve:`);
+    const out = readConfig();
+    expect(out).toContain("devtools({ eventBusConfig: { port: 42188 } })");
+    expect(out).not.toContain("devtools()");
   });
 
-  it("patches clean-it-platform style config (variable assignment)", () => {
+  it("updates existing eventBusConfig port", () => {
+    writeConfig(`import { devtools } from '@tanstack/devtools-vite'
+export default defineConfig({
+  plugins: [
+    devtools({ eventBusConfig: { port: 42070 } }),
+    react(),
+  ],
+})`);
+    const result = patchViteConfig(configPath, { devtoolsPort: 42188 });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain("port: 42188");
+    expect(out).not.toContain("42070");
+  });
+
+  it("adds eventBusConfig to devtools with other args", () => {
+    writeConfig(`import { devtools } from '@tanstack/devtools-vite'
+export default defineConfig({
+  plugins: [
+    devtools({ logging: false }),
+    react(),
+  ],
+})`);
+    const result = patchViteConfig(configPath, { devtoolsPort: 42188 });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain("eventBusConfig: { port: 42188 }");
+    expect(out).toContain("logging: false");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Combined patching (all three at once)
+// ═══════════════════════════════════════════════════════════════════
+
+describe("combined patching", () => {
+  it("applies all three patches to clean-it style config", () => {
     writeConfig(`import { defineConfig } from 'vite'
+import { devtools } from '@tanstack/devtools-vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 const config = defineConfig({
   plugins: [
+    devtools(),
     tailwindcss(),
     tanstackStart(),
     viteReact(),
@@ -216,16 +252,48 @@ const config = defineConfig({
 })
 
 export default config`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
+    const result = patchViteConfig(configPath, {
+      devDomain: DEV_DOMAIN,
+      serverPort: 5188,
+      devtoolsPort: 42188,
+    });
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`server: {`);
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
-    expect(output).toContain(`export default config`);
+    const out = readConfig();
+    expect(out).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(out).toContain("port: 5188,");
+    expect(out).toContain("devtools({ eventBusConfig: { port: 42188 } })");
+    expect(out).toContain("export default config");
+    expect(result.actions.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("skips nft-marketplace style config (already has allowedHosts: true)", () => {
+  it("applies all three to nft-indexer-provisioner style (no devtools)", () => {
+    writeConfig(`import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import tailwindcss from "@tailwindcss/vite"
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { "@": "./src" },
+  },
+})`);
+    const result = patchViteConfig(configPath, {
+      devDomain: DEV_DOMAIN,
+      serverPort: 5190,
+      devtoolsPort: 42190,
+    });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(out).toContain("port: 5190,");
+    expect(out).toContain("resolve:");
+    // devtools not present — should skip
+    expect(result.actions).toContain("devtools: not found, skipped");
+  });
+
+  it("handles nft-marketplace style (existing server + devtools port)", () => {
     writeConfig(`import { defineConfig } from 'vite'
+import { devtools } from '@tanstack/devtools-vite'
 import viteReact from '@vitejs/plugin-react'
 
 const config = defineConfig({
@@ -233,22 +301,36 @@ const config = defineConfig({
     allowedHosts: true,
   },
   plugins: [
+    devtools({ eventBusConfig: { port: 42070 } }),
     viteReact(),
   ],
 })
 
 export default config`);
-    const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
-    expect(result.patched).toBe(false);
-    expect(result.reason).toBe("already allows all hosts (true)");
+    const result = patchViteConfig(configPath, {
+      devDomain: DEV_DOMAIN,
+      serverPort: 5192,
+      devtoolsPort: 42192,
+    });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    // allowedHosts: true → skip (already permissive)
+    expect(result.actions).toContain("allowedHosts: already allows all (true)");
+    // port injected
+    expect(out).toContain("port: 5192,");
+    // devtools port updated
+    expect(out).toContain("port: 42192");
+    expect(out).not.toContain("42070");
   });
 
-  it("patches degen-safe style config (variable, no server block, extra options)", () => {
+  it("handles degen-safe style (extra options, no server block)", () => {
     writeConfig(`import { defineConfig } from 'vite'
+import { devtools } from '@tanstack/devtools-vite'
 import viteReact from '@vitejs/plugin-react'
 
 const config = defineConfig({
   plugins: [
+    devtools(),
     viteReact(),
   ],
   optimizeDeps: {
@@ -260,12 +342,71 @@ const config = defineConfig({
 })
 
 export default config`);
+    const result = patchViteConfig(configPath, {
+      devDomain: DEV_DOMAIN,
+      serverPort: 5194,
+      devtoolsPort: 42194,
+    });
+    expect(result.patched).toBe(true);
+    const out = readConfig();
+    expect(out).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
+    expect(out).toContain("port: 5194,");
+    expect(out).toContain("devtools({ eventBusConfig: { port: 42194 } })");
+    expect(out).toContain("optimizeDeps:");
+    expect(out).toContain("ssr:");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+describe("edge cases", () => {
+  it("returns error for non-existent file", () => {
+    const result = patchViteConfig("/nonexistent/vite.config.ts", {
+      devDomain: DEV_DOMAIN,
+    });
+    expect(result.patched).toBe(false);
+    expect(result.actions).toContain("could not read vite config");
+  });
+
+  it("returns no changes for unrecognized format", () => {
+    writeConfig(`// just a comment`);
+    const result = patchViteConfig(configPath, { devDomain: DEV_DOMAIN, serverPort: 5188 });
+    expect(result.patched).toBe(false);
+  });
+
+  it("is idempotent — second run makes no changes", () => {
+    writeConfig(`export default defineConfig({
+  plugins: [devtools()],
+})`);
+    const first = patchViteConfig(configPath, {
+      devDomain: DEV_DOMAIN,
+      serverPort: 5188,
+      devtoolsPort: 42188,
+    });
+    expect(first.patched).toBe(true);
+    const afterFirst = readConfig();
+
+    const second = patchViteConfig(configPath, {
+      devDomain: DEV_DOMAIN,
+      serverPort: 5188,
+      devtoolsPort: 42188,
+    });
+    expect(second.patched).toBe(false);
+    expect(readConfig()).toBe(afterFirst);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Legacy wrapper
+// ═══════════════════════════════════════════════════════════════════
+
+describe("patchViteAllowedHosts (legacy)", () => {
+  it("still works as before", () => {
+    writeConfig(`export default defineConfig({ plugins: [] })`);
     const result = patchViteAllowedHosts(configPath, DEV_DOMAIN);
     expect(result.patched).toBe(true);
-    const output = readConfig();
-    expect(output).toContain(`server: {`);
-    expect(output).toContain(`allowedHosts: ["${DOMAIN_PATTERN}"]`);
-    expect(output).toContain(`optimizeDeps:`);
-    expect(output).toContain(`ssr:`);
+    expect(result.reason).toContain("allowedHosts");
   });
 });

--- a/src/vite-patch.ts
+++ b/src/vite-patch.ts
@@ -2,99 +2,251 @@ import { readFileSync, writeFileSync } from "fs";
 
 export interface PatchResult {
   patched: boolean;
-  reason: string;
+  actions: string[];
+}
+
+export interface PatchViteConfigOptions {
+  /** Domain for server.allowedHosts (e.g. "dev.web3citadel.com" → [".dev.web3citadel.com"]) */
+  devDomain?: string;
+  /** Port to inject as server.port */
+  serverPort?: number;
+  /** Port for TanStack devtools eventBusConfig (avoids EADDRINUSE on 42069) */
+  devtoolsPort?: number;
 }
 
 /**
- * Patch a Vite config file to include `server.allowedHosts` with the given devDomain.
+ * Patch a Vite config file for zdev worktree use.
  *
- * Handles these real-world patterns:
- *   1. `export default defineConfig({ ... })`
- *   2. `const config = defineConfig({ ... }); export default config`
- *   3. `export default { ... }` (plain object, no defineConfig)
- *   4. Existing `server:` block — merges allowedHosts into it
- *   5. Existing `allowedHosts` array — appends domain if missing
+ * Handles:
+ *   - server.allowedHosts: inject dot-prefix wildcard for devDomain
+ *   - server.port: inject allocated port so TanStack/Nitro picks it up
+ *   - devtools(): inject unique eventBusConfig.port to avoid conflicts
  *
- * Skip conditions:
- *   - File already contains the domain pattern string
- *   - `allowedHosts` is set to `true` or `"all"` (already permissive)
- *   - devDomain is empty
+ * Config patterns supported:
+ *   - `export default defineConfig({ ... })`
+ *   - `const config = defineConfig({ ... })`
+ *   - `export default { ... }`
+ *   - Existing `server:` block — merges into it
  */
-export function patchViteAllowedHosts(
+export function patchViteConfig(
   viteConfigPath: string,
-  devDomain: string
+  options: PatchViteConfigOptions
 ): PatchResult {
-  if (!devDomain) {
-    return { patched: false, reason: "no devDomain configured" };
-  }
+  const actions: string[] = [];
 
   let content: string;
   try {
     content = readFileSync(viteConfigPath, "utf-8");
   } catch {
-    return { patched: false, reason: "could not read vite config" };
+    return { patched: false, actions: ["could not read vite config"] };
   }
 
-  const domainPattern = `.${devDomain}`;
+  const original = content;
 
-  // Skip if domain pattern already present in the file
-  if (content.includes(domainPattern)) {
-    return { patched: false, reason: "domain already present" };
-  }
-
-  // Skip if allowedHosts is already set to a permissive value
-  if (/allowedHosts\s*:\s*true/.test(content)) {
-    return { patched: false, reason: "already allows all hosts (true)" };
-  }
-  if (/allowedHosts\s*:\s*["']all["']/.test(content)) {
-    return { patched: false, reason: 'already allows all hosts ("all")' };
+  // ── 1. server.allowedHosts ──────────────────────────────────────
+  if (options.devDomain) {
+    content = patchAllowedHosts(content, options.devDomain, actions);
   }
 
-  const entry = `"${domainPattern}"`;
-  let patched = false;
-
-  // Case 1: Existing allowedHosts array — append our domain
-  if (/allowedHosts\s*:\s*\[/.test(content)) {
-    content = content.replace(
-      /(allowedHosts\s*:\s*\[)/,
-      `$1${entry}, `
-    );
-    patched = true;
-  }
-  // Case 2: Existing server block without allowedHosts — inject allowedHosts
-  else if (/server\s*:\s*\{/.test(content)) {
-    content = content.replace(
-      /(server\s*:\s*\{)/,
-      `$1\n    allowedHosts: [${entry}],`
-    );
-    patched = true;
-  }
-  // Case 3: defineConfig({ — add server block
-  else if (/defineConfig\s*\(\s*\{/.test(content)) {
-    content = content.replace(
-      /(defineConfig\s*\(\s*\{)/,
-      `$1\n  server: {\n    allowedHosts: [${entry}],\n  },`
-    );
-    patched = true;
-  }
-  // Case 4: export default { — add server block
-  else if (/export\s+default\s*\{/.test(content)) {
-    content = content.replace(
-      /(export\s+default\s*\{)/,
-      `$1\n  server: {\n    allowedHosts: [${entry}],\n  },`
-    );
-    patched = true;
+  // ── 2. server.port ──────────────────────────────────────────────
+  if (options.serverPort) {
+    content = patchServerPort(content, options.serverPort, actions);
   }
 
-  if (!patched) {
-    return { patched: false, reason: "unrecognized config format" };
+  // ── 3. devtools eventBusConfig.port ─────────────────────────────
+  if (options.devtoolsPort) {
+    content = patchDevtoolsPort(content, options.devtoolsPort, actions);
+  }
+
+  // Write only if something changed
+  if (content === original) {
+    return { patched: false, actions: actions.length ? actions : ["no changes needed"] };
   }
 
   try {
     writeFileSync(viteConfigPath, content);
   } catch {
-    return { patched: false, reason: "could not write vite config" };
+    return { patched: false, actions: ["could not write vite config"] };
   }
 
-  return { patched: true, reason: "added allowedHosts" };
+  return { patched: true, actions };
+}
+
+// ── allowedHosts ────────────────────────────────────────────────────
+
+function patchAllowedHosts(content: string, devDomain: string, actions: string[]): string {
+  const domainPattern = `.${devDomain}`;
+
+  // Skip if domain already present
+  if (content.includes(domainPattern)) {
+    actions.push("allowedHosts: domain already present");
+    return content;
+  }
+
+  // Skip if already permissive
+  if (/allowedHosts\s*:\s*true/.test(content)) {
+    actions.push("allowedHosts: already allows all (true)");
+    return content;
+  }
+  if (/allowedHosts\s*:\s*["']all["']/.test(content)) {
+    actions.push('allowedHosts: already allows all ("all")');
+    return content;
+  }
+
+  const entry = `"${domainPattern}"`;
+
+  // Append to existing array
+  if (/allowedHosts\s*:\s*\[/.test(content)) {
+    content = content.replace(/(allowedHosts\s*:\s*\[)/, `$1${entry}, `);
+    actions.push("allowedHosts: appended domain");
+    return content;
+  }
+
+  // Add to existing server block
+  if (/server\s*:\s*\{/.test(content)) {
+    content = content.replace(
+      /(server\s*:\s*\{)/,
+      `$1\n    allowedHosts: [${entry}],`
+    );
+    actions.push("allowedHosts: added to server block");
+    return content;
+  }
+
+  // No server block — will be created by ensureServerBlock below or by port patch
+  // Defer to after server block exists
+  content = ensureServerBlock(content);
+  if (/server\s*:\s*\{/.test(content)) {
+    content = content.replace(
+      /(server\s*:\s*\{)/,
+      `$1\n    allowedHosts: [${entry}],`
+    );
+    actions.push("allowedHosts: created server block");
+  } else {
+    actions.push("allowedHosts: unrecognized config format");
+  }
+
+  return content;
+}
+
+// ── server.port ─────────────────────────────────────────────────────
+
+function patchServerPort(content: string, port: number, actions: string[]): string {
+  // Replace existing server.port
+  if (/server\s*:\s*\{[^}]*\bport\s*:/.test(content)) {
+    content = content.replace(
+      /(server\s*:\s*\{[^}]*\bport\s*:\s*)\d+/,
+      `$1${port}`
+    );
+    actions.push(`server.port: replaced with ${port}`);
+    return content;
+  }
+
+  // Add port to existing server block
+  if (/server\s*:\s*\{/.test(content)) {
+    content = content.replace(
+      /(server\s*:\s*\{)/,
+      `$1\n    port: ${port},`
+    );
+    actions.push(`server.port: injected ${port}`);
+    return content;
+  }
+
+  // No server block — create one
+  content = ensureServerBlock(content);
+  if (/server\s*:\s*\{/.test(content)) {
+    content = content.replace(
+      /(server\s*:\s*\{)/,
+      `$1\n    port: ${port},`
+    );
+    actions.push(`server.port: created server block with port ${port}`);
+  } else {
+    actions.push("server.port: unrecognized config format");
+  }
+
+  return content;
+}
+
+// ── devtools port ───────────────────────────────────────────────────
+
+function patchDevtoolsPort(content: string, port: number, actions: string[]): string {
+  // No devtools import/call — skip
+  if (!content.includes("devtools")) {
+    actions.push("devtools: not found, skipped");
+    return content;
+  }
+
+  // Already has eventBusConfig with a port — replace the port number
+  if (/devtools\s*\([^)]*eventBusConfig\s*:\s*\{[^}]*port\s*:/.test(content)) {
+    content = content.replace(
+      /(devtools\s*\([^)]*eventBusConfig\s*:\s*\{[^}]*port\s*:\s*)\d+/,
+      `$1${port}`
+    );
+    actions.push(`devtools: updated eventBusConfig.port to ${port}`);
+    return content;
+  }
+
+  // devtools() with empty args — inject full config
+  if (/devtools\s*\(\s*\)/.test(content)) {
+    content = content.replace(
+      /devtools\s*\(\s*\)/,
+      `devtools({ eventBusConfig: { port: ${port} } })`
+    );
+    actions.push(`devtools: injected eventBusConfig.port ${port}`);
+    return content;
+  }
+
+  // devtools({ ... }) with args but no eventBusConfig — add it
+  if (/devtools\s*\(\s*\{/.test(content)) {
+    content = content.replace(
+      /(devtools\s*\(\s*\{)/,
+      `$1 eventBusConfig: { port: ${port} },`
+    );
+    actions.push(`devtools: added eventBusConfig.port ${port}`);
+    return content;
+  }
+
+  actions.push("devtools: unrecognized call pattern");
+  return content;
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Ensure a `server: {}` block exists in the config.
+ * Tries defineConfig({ then export default {.
+ */
+function ensureServerBlock(content: string): string {
+  if (/server\s*:\s*\{/.test(content)) {
+    return content; // already exists
+  }
+
+  if (/defineConfig\s*\(\s*\{/.test(content)) {
+    return content.replace(
+      /(defineConfig\s*\(\s*\{)/,
+      `$1\n  server: {\n  },`
+    );
+  }
+
+  if (/export\s+default\s*\{/.test(content)) {
+    return content.replace(
+      /(export\s+default\s*\{)/,
+      `$1\n  server: {\n  },`
+    );
+  }
+
+  return content;
+}
+
+// ── Legacy wrapper (backward compat) ────────────────────────────────
+
+/** @deprecated Use patchViteConfig instead */
+export function patchViteAllowedHosts(
+  viteConfigPath: string,
+  devDomain: string
+): { patched: boolean; reason: string } {
+  const result = patchViteConfig(viteConfigPath, { devDomain });
+  return {
+    patched: result.patched,
+    reason: result.actions.join("; "),
+  };
 }


### PR DESCRIPTION
## Bugs Fixed

**Bug 1 — Port not injected into vite config:**
`zdev start` passes `--port X` to `bun dev`, but TanStack/Nitro ignores CLI port flags. Now injects `server.port` directly into `vite.config.ts` from the allocated port.

**Bug 2 — TanStack devtools port conflict:**
`@tanstack/devtools-event-bus` defaults to port 42069 for its WebSocket server. Multiple worktrees crash with EADDRINUSE. Now injects a unique `eventBusConfig.port` (`frontendPort + 37000`, e.g. 5188 → 42188) into the `devtools()` plugin call.

## Changes

Refactored `patchViteAllowedHosts` → `patchViteConfig`:

| File | Change |
|------|--------|
| `src/vite-patch.ts` | New `patchViteConfig(path, { devDomain, serverPort, devtoolsPort })` — single-pass patching for all three concerns |
| `src/vite-patch.test.ts` | 25 tests (up from 15): 9 allowedHosts + 4 server.port + 4 devtools + 4 combined + 3 edge + 1 legacy |
| `src/commands/start.ts` | Uses `patchViteConfig` with all three options, derives devtoolsPort as `frontendPort + 37000` |

## Example Output

Input (clean-it-platform style):
```ts
const config = defineConfig({
  plugins: [devtools(), tailwindcss(), viteReact()],
})
```

Output:
```ts
const config = defineConfig({
  server: {
    port: 5188,
    allowedHosts: [".dev.web3citadel.com"],
  },
  plugins: [devtools({ eventBusConfig: { port: 42188 } }), tailwindcss(), viteReact()],
})
```

## Tests
```
25 pass, 0 fail, 67 expect() calls
```